### PR TITLE
Fail more helpfully when licence-checker run without config

### DIFF
--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -8,7 +8,6 @@ import argparse
 import fnmatch
 import logging
 import subprocess
-from itertools import groupby
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -330,6 +329,7 @@ def main():
     parser.add_argument("--config",
                         metavar="config.hjson",
                         type=argparse.FileType('r', encoding='UTF-8'),
+                        required=True,
                         help="HJSON file to read for licence configuration.")
     parser.add_argument("paths",
                         metavar="path",


### PR DESCRIPTION
Otherwise, you get something like this:

```
Traceback (most recent call last):
  File "./util/lowrisc_misc-linters/licence-checker/licence-checker.py", line 376, in <module>
    main()
  File "./util/lowrisc_misc-linters/licence-checker/licence-checker.py", line 356, in main
    parsed_config = hjson.load(options.config)
  File "/home/rupert/.local/lib/python3.8/site-packages/hjson/__init__.py", line 117, in load
    return loads(fp.read(),
AttributeError: 'NoneType' object has no attribute 'read'
```