### PR TITLE
Optionally check license using regex

### DIFF
--- a/licence-checker.hjson
+++ b/licence-checker.hjson
@@ -10,6 +10,7 @@
     Licensed under the Apache License, Version 2.0, see LICENSE for details.
     SPDX-License-Identifier: Apache-2.0
     ''',
+  match_regex: 'false',
   exclude_paths: [
     '.style.yapf',
   ],

--- a/licence-checker/README.md
+++ b/licence-checker/README.md
@@ -19,3 +19,27 @@ suffix. This is an artefact of how the checker searches for the licence.
 The checker is configured using a hjson file, which contains the exact licence
 header, and a list of file patterns to exclude from checking the licence for,
 which is used to exclude vendored and other externally sourced files.
+Additionally, the licence checker can be configured to use regex matching using
+the `match_regex` key set to true.
+
+# Configuration Example
+
+```
+{
+  // Licence to check against.
+  licence:
+    '''
+    Copyright lowRISC contributors.
+    Licensed under the Apache License, Version 2.0, see LICENSE for details.
+    SPDX-License-Identifier: Apache-2.0
+    ''',
+  // Optionally match the licence using regex (can be left off).
+  // The default is not to use regex.
+  match_regex: 'false',
+  // Don't consider those paths and files when checking
+  // for the licence (can contain wildcards such as `*`).
+  exclude_paths: [
+    '.style.yapf',
+  ],
+}
+```


### PR DESCRIPTION
Some license headers can include a year or range of years in their
first line, i.e.:

    Copyright [yyyy] [name of copyright owner]

Using exact string matches limits the applicability of the license
checker. Therefore this commit adds the capability to use a regex match
for the first license line to catch such use-cases.