### PR TITLE
Add More SW-Files for OT/Ibex

### DIFF
--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -114,6 +114,7 @@ COMMENT_CHARS = [
 
     # Software Files
     ([".c", ".c.tpl", ".h", ".h.tpl", ".cc", ".cpp"], SLASH_SLASH),  # C, C++
+    ([".def"], SLASH_SLASH),  # C, C++ X-Include List Declaration Files
     ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly
     ([".ld", ".ld.tpl"], SLASH_STAR),  # Linker Scripts
     ([".rs"], SLASH_SLASH),  # Rust

--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -115,7 +115,8 @@ COMMENT_CHARS = [
     # Software Files
     ([".c", ".c.tpl", ".h", ".h.tpl", ".cc", ".cpp"], SLASH_SLASH),  # C, C++
     ([".def"], SLASH_SLASH),  # C, C++ X-Include List Declaration Files
-    ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly
+    ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly (With Preprocessing)
+    ([".s"], SLASH_STAR),  # Assembly (Without Preprocessing)
     ([".ld", ".ld.tpl"], SLASH_STAR),  # Linker Scripts
     ([".rs"], SLASH_SLASH),  # Rust
 


### PR DESCRIPTION
This adds a few new file kinds
- `.s` files for assembly (which should not be preprocessed)
- `.def` files for X-Include Declaration Lists. These are used in ibex: https://github.com/lowRISC/ibex/blob/master/dv/cs_registers/reg_driver/csr_listing.def and may be used in OpenTitan soon. They're effectively C/C++ (but are only really used by the preprocessor).

