### PR TITLE
[licence-checker] add support for non-standalone header templates

### DIFF
--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -131,8 +131,10 @@ COMMENT_CHARS = [
     ([".do"], SLASH_SLASH),  # Cadence LEC dofile
 
     # Software Files
-    ([".c", ".c.tpl", ".h", ".h.tpl", ".cc", ".cc.tpl", ".cpp",
-      ".cpp.tpl"], SLASH_SLASH),  # C, C++
+    ([
+        ".c", ".c.tpl", ".h", ".h.tpl", ".inc", ".inc.tpl", ".cc", ".cc.tpl",
+        ".cpp", ".cpp.tpl"
+    ], SLASH_SLASH),  # C, C++
     ([".def"], SLASH_SLASH),  # C, C++ X-Include List Declaration Files
     ([".S"], [SLASH_SLASH, SLASH_STAR]),  # Assembly (With Preprocessing)
     ([".s"], SLASH_STAR),  # Assembly (Without Preprocessing)


### PR DESCRIPTION
Non-standalone (C) headers are those that are design to be included by
other headers only, and have the extension: "*.inc".