### PR TITLE
[bazel] Let repositories that depend on this one BTOP

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,11 @@ http_archive(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
+load("//rules:repos.bzl", "lowrisc_misc_linters_repos")
+lowrisc_misc_linters_repos()
+
 load("//rules:deps.bzl", "lowrisc_misc_linters_dependencies")
 lowrisc_misc_linters_dependencies()
+
 load("//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
 lowrisc_misc_linters_pip_dependencies()

--- a/rules/deps.bzl
+++ b/rules/deps.bzl
@@ -2,15 +2,13 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dependencies that linter rules depend on."""
+"""Dependencies for linter rules."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 def lowrisc_misc_linters_dependencies():
-  """Declares workspaces linting rules depend on.
-  Make sure to call this in your WORKSPACE file."""
-  http_archive(
-      name = "rules_python",
-      url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
-      sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
-  )
+    if not native.existing_rule("python3"):
+        python_register_toolchains(
+            name = "python3",
+            python_version = "3.9",
+        )

--- a/rules/pip.bzl
+++ b/rules/pip.bzl
@@ -5,6 +5,7 @@
 """Dependencies that linter rules depend on."""
 
 load("@rules_python//python:pip.bzl", "pip_install")
+load("@python3//:defs.bzl", "interpreter")
 
 def lowrisc_misc_linters_pip_dependencies():
   """
@@ -17,5 +18,6 @@ def lowrisc_misc_linters_pip_dependencies():
 
   pip_install(
      name = "lowrisc_misc_linters_pip",
+     python_interpreter_target = interpreter,
      requirements = Label("//:requirements.txt"),
   )

--- a/rules/repos.bzl
+++ b/rules/repos.bzl
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repositories to provide dependencies for the linter rules."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def lowrisc_misc_linters_repos():
+    """Declares workspaces linting rules depend on.
+    Make sure to call this in your WORKSPACE file."""
+    if not native.existing_rule("rules_python"):
+        http_archive(
+            name = "rules_python",
+            sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
+            strip_prefix = "rules_python-0.8.0",
+            url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
+        )


### PR DESCRIPTION
We want this to let repositories that depend on it to bring their own python and keep it reproducible.

(Re-upload of https://github.com/lowRISC/misc-linters/pull/26, since Drew is on vacation.)