### PR TITLE
Create a licence_test rule

### DIFF
--- a/licence-checker/BUILD
+++ b/licence-checker/BUILD
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
+
 load("@lowrisc_misc_linters_pip//:requirements.bzl", "requirement")
 
 py_binary(
     name = "licence-checker",
     srcs = ["licence-checker.py"],
     deps = [
-        requirement('hjson'),
-        requirement('tabulate'),
+        requirement("hjson"),
+        requirement("tabulate"),
     ],
 )

--- a/rules/licence-checker-runner.template.sh
+++ b/rules/licence-checker-runner.template.sh
@@ -3,8 +3,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-if ! cd "$BUILD_WORKSPACE_DIRECTORY"; then
-    echo "Unable to change to workspace (BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY})"
+WORKSPACE="@@WORKSPACE@@"
+
+if [[ ! -z "${WORKSPACE}" ]]; then
+    REPO="$(dirname "$(realpath ${WORKSPACE})")"
+    cd ${REPO} || exit 1
+elif [[ ! -z "${BUILD_WORKSPACE_DIRECTORY+is_set}" ]]; then
+    cd ${BUILD_WORKSPACE_DIRECTORY} || exit 1
+else
+    echo "Neither WORKSPACE nor BUILD_WORKSPACE_DIRECTORY were set."
+    echo "If this is a test rule, add 'workspace = \"//:WORKSPACE\"' to your rule."
     exit 1
 fi
 


### PR DESCRIPTION
The `license_test` rule executes the licence checker as a bazel test
(rather than an executable), thus allowing an upstream project to
use the rule as part of a set of presubmit tests.

Signed-off-by: Chris Frantz <cfrantz@google.com>