### PR TITLE
Add all hjson comment styles to licence checker

### DIFF
--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -159,7 +159,7 @@ COMMENT_CHARS = [
     (["Dockerfile"], HASH),  # Dockerfiles
 
     # Configuration
-    ([".hjson"], SLASH_SLASH),  # hjson
+    ([".hjson"], [SLASH_SLASH, SLASH_STAR, HASH]),  # hjson
     ([".yml", ".yaml"], HASH),  # YAML
     ([".toml"], HASH),  # TOML
     (["-requirements.txt"], HASH),  # Apt and Python requirements files


### PR DESCRIPTION
Hjson supports slash/slash, slash/star and hash style comments (see https://hjson.github.io/). This PR adds them all to the licence checker script.