### PR TITLE
[bazel] fix python package error on debian systems

### DIFF
--- a/rules/pip.bzl
+++ b/rules/pip.bzl
@@ -37,6 +37,7 @@ def _pip_wheel_impl(rctx):
         "-m",
         "pip",
         "install",
+        "--user",
         "wheel",
     ]
     rctx.report_progress("Installing the Python wheel package")
@@ -54,6 +55,7 @@ def _pip_wheel_impl(rctx):
         "-m",
         "pip",
         "wheel",
+        "--use-pep517",
         "-r",
         rctx.path(rctx.attr.requirements),
         "-w",


### PR DESCRIPTION
This is a port of https://github.com/lowRISC/opentitan/pull/21955 to this repo.