### PR TITLE
Update `rules_python` to 0.34.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 module(name = "lowrisc_misc_linters")
 
 bazel_dep(name = "rules_python", version = "0.34.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(name = "lowrisc_misc_linters")
 
-bazel_dep(name = "rules_python", version = "0.32.2")
+bazel_dep(name = "rules_python", version = "0.34.0")
 bazel_dep(
     name = "aspect_rules_lint",
     version = "1.0.0-rc3",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ load("@lowrisc_lint//rules:deps.bzl", "lowrisc_misc_linters_dependencies")
 lowrisc_misc_linters_dependencies()
 load("@lowrisc_lint//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
 lowrisc_misc_linters_pip_dependencies()
+load("@lowrisc_misc_linters_pip//:requirements.bzl", "install_deps")
+install_deps()
 ```
 
 If using `bzlmod`, instead add the following to `MODULE.bazel`:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,9 @@ lowrisc_misc_linters_dependencies()
 load("//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
 lowrisc_misc_linters_pip_dependencies()
 
+load("@lowrisc_misc_linters_pip//:requirements.bzl", "install_deps")
+install_deps()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "aspect_rules_lint",

--- a/rules/deps.bzl
+++ b/rules/deps.bzl
@@ -4,10 +4,11 @@
 
 """Dependencies for linter rules."""
 
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+load("@rules_python//python:repositories.bzl", "python_register_toolchains", "py_repositories")
 
 def lowrisc_misc_linters_dependencies():
     if not native.existing_rule("python3"):
+        py_repositories()
         python_register_toolchains(
             name = "python3",
             python_version = "3.9",

--- a/rules/pip.bzl
+++ b/rules/pip.bzl
@@ -4,102 +4,8 @@
 
 """Dependencies that linter rules depend on."""
 
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:pip.bzl", "pip_parse")
 load("@python3//:defs.bzl", "interpreter")
-
-_WHEEL_BUILD_FILE_CONTENTS = """\
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "all_wheels",
-    srcs = glob(["**/*.whl"])
-)
-"""
-
-def _pip_wheel_impl(rctx):
-    # First, check if an existing pre-built Python wheels repo exists, and if
-    # so, use it instead of building one.
-    python_wheel_repo_path = rctx.os.environ.get(
-        "BAZEL_PYTHON_WHEELS_REPO",
-        None,
-    )
-    if python_wheel_repo_path:
-        rctx.report_progress("Mounting existing Python wheels repo")
-        rctx.symlink(python_wheel_repo_path, ".")
-        return
-
-    # If a pre-built Python wheels repo does not exist, we need to build it.
-    rctx.report_progress("No Python wheels repo detected, building it instead")
-
-    # First, we install the Python wheel package so we can build other wheels.
-    args = [
-        rctx.path(rctx.attr.python_interpreter),
-        "-m",
-        "pip",
-        "install",
-        "--user",
-        "wheel",
-    ]
-    rctx.report_progress("Installing the Python wheel package")
-    result = rctx.execute(
-        args,
-        timeout = rctx.attr.timeout,
-        quiet = rctx.attr.quiet,
-    )
-    if result.return_code:
-        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
-
-    # Next, we download/build all the Python wheels for each requirement.
-    args = [
-        rctx.path(rctx.attr.python_interpreter),
-        "-m",
-        "pip",
-        "wheel",
-        "--use-pep517",
-        "-r",
-        rctx.path(rctx.attr.requirements),
-        "-w",
-        "./",
-    ]
-    rctx.report_progress("Pre-building Python wheels")
-    result = rctx.execute(
-        args,
-        timeout = rctx.attr.timeout,
-        quiet = rctx.attr.quiet,
-    )
-    if result.return_code:
-        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
-
-    # We need a BUILD file to load the downloaded Python packages.
-    rctx.file(
-        "BUILD.bazel",
-        _WHEEL_BUILD_FILE_CONTENTS,
-    )
-
-pip_wheel = repository_rule(
-    implementation = _pip_wheel_impl,
-    attrs = {
-        "python_interpreter": attr.label(
-            default = interpreter,
-            allow_single_file = True,
-            doc = "Python interpreter to use.",
-        ),
-        "requirements": attr.label(
-            default = "//:requirements.txt",
-            allow_single_file = True,
-            doc = "Python requirements file describing package dependencies.",
-        ),
-        "quiet": attr.bool(
-            default = True,
-            doc = "If True, suppress printing stdout/stderr to the terminal.",
-        ),
-        "timeout": attr.int(
-            default = 300,
-            doc = "Timeout (in seconds) on the rule's execution duration.",
-        ),
-    },
-    environ = ["BAZEL_PYTHON_WHEELS_REPO"],
-)
 
 def lowrisc_misc_linters_pip_dependencies():
     """
@@ -109,13 +15,8 @@ def lowrisc_misc_linters_pip_dependencies():
     Make sure to call lowrisc_misc_linters_dependencies() from
     deps.bzl first.
     """
-    pip_wheel(
-        name = "lowrisc_misc_linters_wheels",
-    )
-    pip_install(
+    pip_parse(
         name = "lowrisc_misc_linters_pip",
         python_interpreter_target = interpreter,
-        requirements = Label("//:requirements.txt"),
-        find_links = "@lowrisc_misc_linters_wheels//:all_wheels",
-        extra_pip_args = ["--no-index"],
+        requirements_lock = Label("//:requirements.txt"),
     )

--- a/rules/repos.bzl
+++ b/rules/repos.bzl
@@ -12,7 +12,7 @@ def lowrisc_misc_linters_repos():
     if not native.existing_rule("rules_python"):
         http_archive(
             name = "rules_python",
-            sha256 = "9e9a58cff49f80afd1c9fcc7137b719531f7a7427cce4fda1d30ca27b4a46a8a",
-            strip_prefix = "rules_python-07c3f8547abbd5b97839a48af226a0fbcfaa5e7c",
-            url = "https://github.com/lowRISC/rules_python/archive/07c3f8547abbd5b97839a48af226a0fbcfaa5e7c.tar.gz",
+            sha256 = "778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618",
+            strip_prefix = "rules_python-0.34.0",
+            url = "https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz",
         )


### PR DESCRIPTION
This is a breaking change: `rules_python` deprecated `pip_install` in recent versions.

You must now call `pip_parse` on the _lock_ file and then install the dependencies generated into the repo.

I believe every user has to call the `install_deps` step which isn't great. I tried merging this into `lowrisc_misc_linters_pip_dependencies()` but couldn't get that to work.