### PR TITLE
Correct comment style for Mako templates

### DIFF
--- a/licence-checker/licence-checker.py
+++ b/licence-checker/licence-checker.py
@@ -93,11 +93,13 @@ class BlockCommentStyle(CommentStyle):
 
 SLASH_SLASH = "//"
 HASH = "#"
+HASH_HASH = "##"
 SLASH_STAR = "/*"
 
 COMMENT_STYLES = {
     SLASH_SLASH: LineCommentStyle("//"),
     HASH: LineCommentStyle("#"),
+    HASH_HASH: LineCommentStyle("##"),
     SLASH_STAR: BlockCommentStyle("/*", "*/"),
     "corefile": DifferentFirstLineCommentStyle("CAPI=2", "#"),
 }
@@ -175,7 +177,7 @@ COMMENT_CHARS = [
     ([".css"], SLASH_STAR),  # CSS
     ([".scss"], SLASH_SLASH),  # SCSS
     # Templates (Last because there are overlaps with extensions above)
-    ([".tpl"], HASH),  # Mako templates
+    ([".tpl"], [HASH_HASH, HASH]),  # Mako templates
 ]
 
 


### PR DESCRIPTION
According to the [Mako documentation](https://docs.makotemplates.org/en/latest/syntax.html#comments) comments should start with `##` instead of `#`.
However, in this commit I have left the single `#` as an option as some files (in the opentitan repository) already rely on it.

Note: I have fixed the offending file in [opentitan#26151](https://github.com/lowRISC/opentitan/pull/26151). If that PR is merged first, then I can also correct the Mako comment style here and remove the single `#`. However, I must admit that I am not 100% certain that this wouldn't break anything outside the opentitan repository.