### PR TITLE
Bump Python to v3.10

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,12 +12,12 @@ bazel_dep(
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.9")
+python.toolchain(python_version = "3.10")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "pip",
-    python_version = "3.9",
+    python_version = "3.10",
     requirements_lock = "//:requirements.txt",
 )
 use_repo(pip, lowrisc_misc_linters_pip="pip")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,8 @@ bazel_dep(
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(python_version = "3.10")
+use_repo(python, "pythons_hub")
+register_toolchains("@pythons_hub//:all")
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -9,5 +9,5 @@ local_path_override(module_name = "lowrisc_misc_linters", path = "../")
 
 bazel_dep(name = "rules_python", version = "0.34.0")
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.9")
+python.toolchain(python_version = "3.10")
 


### PR DESCRIPTION
Also actually register the toolchain this time. I think with this registered correctly, other modules can use different python versions without this breaking.